### PR TITLE
Update dash-button library

### DIFF
--- a/button-pressed.js
+++ b/button-pressed.js
@@ -3,23 +3,20 @@ var dash_button = require('node-dash-button'),
 
 module.exports = function(RED) {
     function node (config) {
-        
         RED.nodes.createNode(this, config);
         var node = this;
-        
-        var mac = config.mac || '';
-        
-        console.log(mac);
 
-        var dash = dash_button(mac); 
+        var mac = config.mac || '';
+        var dash = dash_button(mac, null, null, 'all');
         var found = function () {
             console.log('Button Pressed: ' + mac);
-            var msg = {};
-            node.send(msg);
+            node.send({
+                payload: mac
+            });
         };
-        
+
         dash.on("detected", _.debounce(found, 5000, true));
     };
- 
+
     RED.nodes.registerType("ButtonPressed",node);
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     }
   },
   "dependencies": {
-    "node-dash-button": "^0.3.0",
+    "node-dash-button": "^0.6.1",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
**Why is this necessary ?**
- With the default version the dash buttons work unreliably.

**What does the new version change ?** 
- Previous versions use `ARP` only detection to detect the dash buttons. (`Who has 192.168.1.1 tell 192.168.1.x`)
The newer version allows to also listen vor UDP/DHCP requests which is much more reliable
