### PR TITLE
Multiple mac addresses + select network interface

### DIFF
--- a/button-pressed.html
+++ b/button-pressed.html
@@ -4,7 +4,8 @@
         color: '#F3EC14',
         defaults: {
             name: {value:"Dash Button"},
-            mac: {value:""}
+            mac: {value:""},
+            interface: {value:""}
         },
         inputs:0,
         outputs:1,
@@ -24,11 +25,16 @@
 
     <div class="form-row">
         <label for="node-input-mac">Dash MAC</label>
-        <input type="text" id="node-input-mac" placeholder="00:00:00:00:00:00">
+        <input type="text" id="node-input-mac" placeholder="00:00:00:00:00:00,00:00:00:00:00:00">
+    </div>
+    <div class="form-row">
+        <label for="node-input-interface">Network interface</label>
+        <input type="text" id="node-input-interface">
     </div>
 
 </script>
 
 <script type="text/x-red" data-help-name="ButtonPressed">
-    <p>Configure the node with the Dash Button MAC Address</p>
+    <p>Configure the node with the Dash Button MAC Address (use comma <code>,</code> to separate multiple mac addresses)</p>
+    <p>You can optionally add the network interface to use for your Dash Buttons</p>
 </script>

--- a/button-pressed.js
+++ b/button-pressed.js
@@ -8,15 +8,16 @@ module.exports = function(RED) {
         var node = this;
         
         var mac = config.mac || '';
-
+        // if there are mutliple addresses we split the chain
+        mac.split(',');
         
         var interface = config.interface || null;
         console.log(mac);
 
         var dash = dash_button(mac, interface); 
-        var found = function () {
+        var found = function (dash_id) {
             console.log('Button Pressed: ' + dash_id);
-            var msg = {"mac": mac};
+            var msg = {"mac": dash_id};
             node.send(msg);
         };
         

--- a/button-pressed.js
+++ b/button-pressed.js
@@ -8,13 +8,15 @@ module.exports = function(RED) {
         var node = this;
         
         var mac = config.mac || '';
+
         
+        var interface = config.interface || null;
         console.log(mac);
 
-        var dash = dash_button(mac); 
+        var dash = dash_button(mac, interface); 
         var found = function () {
-            console.log('Button Pressed: ' + mac);
-            var msg = {};
+            console.log('Button Pressed: ' + dash_id);
+            var msg = {"mac": mac};
             node.send(msg);
         };
         

--- a/button-pressed.js
+++ b/button-pressed.js
@@ -9,7 +9,7 @@ module.exports = function(RED) {
         
         var mac = config.mac || '';
         // if there are mutliple addresses we split the chain
-        mac.split(',');
+        mac = mac.split(',');
         
         var interface = config.interface || null;
         console.log(mac);


### PR DESCRIPTION
I added the option to configure multiple comma separated mac addresses to a single dash node (as seen in the README of [node-dash-button](https://github.com/hortinstein/node-dash-button) library .
I also added a config field for the network interface on which to listen to traffic
 
The node now outputs a messsage containing the mac address of the detected dash button which should allow to filter the output and act accordingly